### PR TITLE
Model Mapping to WireBox converter

### DIFF
--- a/src/handlers/wirebox/WireBoxMMToWireBox.cfm
+++ b/src/handlers/wirebox/WireBoxMMToWireBox.cfm
@@ -1,0 +1,74 @@
+<!-----------------------------------------------------------------------
+********************************************************************************
+Copyright Since 2005 ColdBox Framework by Luis Majano and Ortus Solutions, Corp
+www.coldboxframework.com | www.luismajano.com | www.ortussolutions.com
+********************************************************************************
+
+Author      :	Brad Wood
+Date        :	02/27/2010
+
+All handlers receive the following:
+- data 		  : The data parsed
+- inputStruct : A parsed input structure
+----------------------------------------------------------------------->
+<cfscript>
+// MMFile
+mmFile 	= data.event.ide.projectview.resource.XMLAttributes.path;
+wbFile	= getDirectoryFromPath(mmFile) & "/WireBox.cfc";
+converter 		= createObject("component","coldboxExtension.model.util.MMToWireBox").init();
+// start conversion
+results = converter.convert(mmFile);
+// Create WireBox Binder
+if( NOT len(results.errorMessages) ){
+	template = fileRead("#ExpandPath('../../')#templates/wirebox/WireBox.txt");
+	template = replacenocase(template,"|mapBindings|",results.data);
+	fileWrite(wbFile, template);
+}
+</cfscript>
+
+<!--- Display --->
+<cfheader name="Content-Type" value="text/xml">  
+<cfoutput>
+<response status="success" showresponse="true">  
+<ide> 
+	<cfif not len(results.errorMessages)> 
+	<commands>
+		<command type="RefreshProject">
+			<params>
+			    <param key="projectname" value="#data.event.ide.projectview.xmlAttributes.projectname#" />
+			</params>
+		</command>
+		<command type="openfile">
+			<params>
+			    <param key="filename" value="#wbFile#" />
+			</params>
+		</command>
+	</commands>
+	</cfif>
+	<dialog width="600" height="250" title="WireBox Model Mapping Converter" image="includes/images/ColdBox_Icon.png"/>  
+	<body> 
+	<![CDATA[ 
+	<html>
+		<head>
+			<base href="#controller.getBaseURL()#" />
+			<link href="includes/css/styles.css" type="text/css" rel="stylesheet">
+			<script type="text/javascript" src="includes/js/jquery.latest.min.js"></script>
+		</head>
+		<body>
+			<cfif len(results.errorMessages)>
+				<div class="messagebox">
+				#results.errorMessages#
+				</div>
+			<cfelse>
+				<div class="messagebox-green">
+					Model Mapping To WireBox conversion finalized! We have created a WireBox 
+					configuration binder for you and opened it!
+				</div>
+			</cfif>
+		</body>
+	</html>
+	]]> 
+	</body> 
+</ide>
+</response>
+</cfoutput>

--- a/src/ide_config.xml
+++ b/src/ide_config.xml
@@ -203,6 +203,9 @@
 					<action name="Convert ColdSpring To WireBox" 	handlerid="WireBoxCSToWireBox"	showResponse="true">
 						<filters><filter type="file" pattern=".*\.(xml\.cfm|xml)" /></filters>
 					</action>
+					<action name="Convert Legacy Model Mappings To WireBox" 	handlerid="WireBoxMMToWireBox"	showResponse="true">
+						<filters><filter type="file" pattern="modelMappings.cfm" /></filters>
+					</action>
 					<action name="New Binder" 		handlerid="WireBoxGenBinder"		showResponse="true">
 						<filters><filter type="folder" /></filters>
 					</action>
@@ -295,6 +298,7 @@
 		<handler id="WireBoxSetterInjection" 		type="CFM" filename="wirebox/WireBoxSetterInjection.cfm" />
 		<handler id="WireBoxComponentPersitence" 	type="CFM" filename="wirebox/WireBoxComponentPersitence.cfm" />
 		<handler id="WireBoxCSToWireBox" 			type="CFM" filename="wirebox/WireBoxCSToWireBox.cfm" />
+		<handler id="WireBoxMMToWireBox" 			type="CFM" filename="wirebox/WireBoxMMToWireBox.cfm" />
 		<handler id="WireBoxGenBinder" 				type="CFM" filename="wirebox/WireBoxGenBinder.cfm" />
 		<handler id="WireBoxProviderMethod" 		type="CFM" filename="wirebox/WireBoxProviderMethod.cfm" />
 		

--- a/src/model/util/MMToWireBox.cfc
+++ b/src/model/util/MMToWireBox.cfc
@@ -1,0 +1,57 @@
+<!-----------------------------------------------------------------------
+********************************************************************************
+Copyright 2005-2007 ColdBox Framework by Luis Majano and Ortus Solutions, Corp
+www.coldboxframework.com | www.luismajano.com | www.ortussolutions.com
+********************************************************************************
+
+Model Mapping Converter to WireBox
+
+----------------------------------------------------------------------->
+<cfcomponent output="false" hint="CS Converter to WireBox">
+
+	<cffunction name="init" access="public" returnType="MMToWireBox" output="false" hint="Constructor">
+		<cfscript>
+			return this;
+		</cfscript>
+	</cffunction>
+	
+	<!--- convert --->
+	<cffunction name="convert" access="public" returntype="struct" hint="Convert to WireBox" output="false" >
+		<cfargument name="filePath"	required="true">
+		<cfscript>
+			var results = {
+				errorMessages = "",
+				data = ""
+			};
+			var local = {};
+			// regex for non-greedy match of the first <cfscript> tag contents
+			local.scriptContentsRegex = ".*?<cfscript>(.*?)<\/cfscript>.*";
+			// regex to match calls to addModelMapping()
+			local.MMToWBRegex = "addModelMapping\s*\(\s*(alias\s*=\s*)?([^;]*?)\s*,\s*(path\s*=\s*)?\s*([^;]*?)\s*\)\s*";
+			
+			// Parsing
+			try{
+				local.mmCFML = fileRead(arguments.filePath);
+
+				// Extract the contents of the first cfscript tag.
+				// If important logic was included outside these tags, this won't work too well.
+				results.data = reReplaceNoCase(local.mmCFML,local.scriptContentsRegex,"\1","ONE");
+				
+				// Replace wach addModelMapping() call with map().to()
+		 		results.data = reReplaceNoCase(results.data,local.MMToWBRegex,"map(\2).to(\4)","ALL");
+ 		
+			}
+			catch(any e){
+				results.errorMessages = "Error parsing model mappings: #e.message# #e.detail# #e.stacktrace#";
+			}
+			
+			return results;
+		</cfscript>
+	</cffunction>
+	
+	<!--- getUtil --->
+	<cffunction name="getUtil" output="false" access="private" returntype="any" hint="Get the utility object">
+		<cfreturn createObject("component","coldboxExtension.model.util.Utility")>
+	</cffunction>
+
+</cfcomponent>


### PR DESCRIPTION
This adds a menu item that shows up when you click on a file called modelMappings.cfm.  It is called "Convert Legacy Model Mappings To WireBox" and it will extract the contents of the first cfscript tag, and replace each call to addModelMapping() with the map().to() DSL and write out a new WireBox.cfc binder based on the same template that the ColdSpring to WireBox converter uses.  

It seems to work ok, for a number of scenarios that I've come up with, but I would like to see some people give it a try with their model mappings to see if it has any obvious loop holes.  
